### PR TITLE
Update 4-eslint-config.md

### DIFF
--- a/code-301/4-eslint-config.md
+++ b/code-301/4-eslint-config.md
@@ -4,7 +4,7 @@
 
 Copy the following line and paste into your terminal.  This will globally install the `eslint-plugin-react` package and will ensure that your React specific code is properly linted.
 
-`$ npm i -g eslint-plugin-react`
+`npm i -g eslint-plugin-react`
 
 Navigate to the root of your computer and add the following to your `eslintrc.json` file:
 


### PR DESCRIPTION
We don't include the command prompt symbol in any other "copy paste"-able commands, so I don't think we should here either.

Students will copy the whole line, and get strange errors because the `$` is pasted in. 
