### PR TITLE
changing the id in the nano configs to reflect the id name the guide …

### DIFF
--- a/system-setup/5-git.md
+++ b/system-setup/5-git.md
@@ -158,7 +158,7 @@ In order to use Git locally in a secure manner, we need to connect our computer 
        Host *
          AddKeysToAgent yes
          UseKeychain yes
-         IdentityFile ~/.ssh/id_ed25519
+         IdentityFile ~/.ssh/id_rsa
        ```
 
       - Press `ctrl-x` then press `y` then press `enter`


### PR DESCRIPTION
…has asked us to make. ed25519 is the default the github guide uses, not the rsa example from the Code Fellows guide. This resolves the command line not finding the key upon machine sleep or restart.