### PR TITLE
Profile shouldn't `cd ~`

### DIFF
--- a/system-setup/1-environment.md
+++ b/system-setup/1-environment.md
@@ -41,8 +41,6 @@ From your terminal, run these commands
 
 The changes you just made will take effect every time you re-open your terminal. But right now, we want to see those changes immediately, so let's "source it" by running:
 
-`echo cd ~ >> .profile`
-
 `source ~/.profile`
 
 - NOTE: You will see an error along the lines of `-bash: /home/linuxbrew/.linuxbrew/bin/brew: No such file or directory`.  This is ok for now.


### PR DESCRIPTION
Not sure why this is here, but it doesn't make sense for a terminal to force changing to `~`. That's where shells open by default, but opening a shell in VS Code, for example, should stay in the project folder.