### PR TITLE
Update 9-vscode.md

### DIFF
--- a/system-setup/9-vscode.md
+++ b/system-setup/9-vscode.md
@@ -40,9 +40,8 @@ VSCode should open up and show a list of files in the current directory.
 
 - liveserver
 - ESLint
-- Markdown Lint
+- markdownlint
 - HTML Preview
-- Debugger for Chrome
 - **Windows Users Only** - Remote WSL
 
 There are many other extensions to choose from that will make your coding life a lot easier. Your instructors, TAs and classmates will all be great resources as to what works well for them.


### PR DESCRIPTION
Line 43 originally said "Markdown Lint". Since "liveserver" is one word with that capitalization, I expected "Markdown Lint" to be the same. There is no "Markdown Lint" extension however.  "markdownlint" by David Anson (davidanson.vscode-markdownlint) has 2,962,143 downloads and high star marks. I assume it is meant to be this one, and would like to save someone a few minutes of heartache.

Also removed line 45 - Debugger for Chrome.
According to the package info (msjsdiag.debugger-for-chrome) by Microsoft, this extension has been deprecated as VS Code has a bundled JavaScript Debugger that does the same functionality.