### PR TITLE
Remove Rainbow Brackets from suggested VSCode plugins

### DIFF
--- a/system-setup/10-vscode.md
+++ b/system-setup/10-vscode.md
@@ -44,7 +44,6 @@ VSCode should open up and show a list of files in the current directory.
 - editorconfig
 - HTML Preview
 - Thunder Client
-- Rainbow Brackets
 - **Windows Users Only:** Remote WSL
 
 There are many other extensions to choose from that will make your coding life a lot easier. Your instructors, TAs and classmates will all be great resources as to what works well for them.


### PR DESCRIPTION
Bracket Pair Colorization is available and enabled without extensions starting in VSCode April 2022.

https://code.visualstudio.com/updates/v1_67#_bracket-pair-colorization-enabled-by-default