### PR TITLE
add Elastic Beanstalk to AWS install

### DIFF
--- a/code-401-javascript/3-aws.md
+++ b/code-401-javascript/3-aws.md
@@ -15,6 +15,15 @@ As part of the 401 Curriculum and beyond, you'll be using various cloud service 
    ```bash
    aws-cli/2.0.19 Python/3.8.3 Linux/4.19.104-microsoft-standard botocore/2.0.0dev23
    ```
+1. Install the Elastic Beanstalk CLI tools, by running this command in your terminal:
+   - `brew install awsebcli`
+1. Confirm proper installation
+   - `eb --version`
+   - You should see output with these versions or higher:
+
+   ```bash
+   EB CLI 3.20.3 (Python 3.10.)
+   ```
 
 ---
 


### PR DESCRIPTION
lab-16 requires that EB-CLI be installed for task 2 competition.  adding to setup is helpful