### PR TITLE
Updated version number in verification step for oh-my-zsh

### DIFF
--- a/system-setup/6-ohmyzsh.md
+++ b/system-setup/6-ohmyzsh.md
@@ -6,7 +6,7 @@ Now it's time to unleash your terminal potential.
 
 - In your terminal, run: `zsh --version`
   - *If output is this version or higher*:
-    - `zsh 5.9`
+    - `zsh 5.8`
     - Continue to [next page](./7-node.md)
   - *If output is not similar to the above*, continue with instructions on this page.
 


### PR DESCRIPTION
Many students were getting stuck on the oh-my-zsh step because their version was 5.8 and the "Verify if Oh-My-Zsh is already installed" section it showed 5.9. Changed the guide to say 5.8.