### PR TITLE
add mongoDB install clause for wsl2 users.

### DIFF
--- a/code-301/1-database.md
+++ b/code-301/1-database.md
@@ -29,6 +29,8 @@ brew services start mongodb-community
 
 ### Windows/WSL Users
 
+> Note: Because of ongoing WSL2 changes, local install may not simply work.  If this is the case, your instructor will have an online option they will share in class. If your MongoDB installation does not work after the first attempt, take a screen shot of the terminal to submit in place of the `mongosh` validation (mentioned below), and *move forward without local MongoDB installation.* 
+
 **Complete the following sections of [Microsoft's directions](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-database#install-mongodb{:target="_blank"}).**
 
 - [Install MongoDB](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-database#install-mongodb){:target="_blank"}


### PR DESCRIPTION
not sure if this is the path we would like to take, but raising the question in code if helpful.  many 301 students experience a significant time-dump (time dump for students and TAs actually) when trying to install mongoDB locally.  The answer always seems to be the same "oh, that thing we told you to do, you don't actually need to do it".  

Instructions  for the "what-if" or "eventuality of" failure would preserve everyone's time and most importantly save student bandwidth for being 301 ready!  Can we just call it out and reap the quality of life benefits across the org?

Alternatively, can the MongoDB install just go away, even if just for now?  because we allow WSL usage, using Ajax is just the way we teach them in class anyway!  why have half the class install mongoDB which is never used locally?